### PR TITLE
Feature/Add docker-compose file for MongoDB and Redis containers

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  mongodb:
+    image: mongo
+    ports:
+      - 27017:27017
+  redis:
+    image: redis
+    ports:
+      - 6379:6379


### PR DESCRIPTION
This commit adds a docker-compose file to the server folder that can be used to run MongoDB and Redis containers with a single command. The file uses the official MongoDB and Redis images and maps the container's default ports to the host. The containers are set to run in the foreground for ease of use and debugging.