### PR TITLE
Show video thumbnail

### DIFF
--- a/server/src/modules/db/schemas/videos.js
+++ b/server/src/modules/db/schemas/videos.js
@@ -93,16 +93,32 @@ const updateSchema = async (db) => {
         },
         thumbnailUrl: {
           bsonType: 'string',
-          description: 'must be a string and is required',
+          description: 'must be a string',
+        },
+        thumbnailPath: {
+          bsonType: 'string',
+          description: 'must be a string',
+        },
+        processedPath: {
+          bsonType: 'string',
+          description: 'must be a string',
+        },
+        hlsPath: {
+          bsonType: 'string',
+          description: 'must be a string',
         },
         tags: {
           bsonType: 'array',
-          description: 'must be an array and is required',
+          description: 'must be an array',
         },
         publishedAt: {
           bsonType: 'date',
-          description: 'must be a date and is required',
+          description: 'must be a date',
         },
+        history: {
+          bsonType: 'array',
+          description: 'must be a array',
+        }
       },
     },
   };

--- a/server/src/modules/models/video/service.js
+++ b/server/src/modules/models/video/service.js
@@ -37,7 +37,8 @@ const search = async (searchObject) => {
     category: 1,
     duration: 1,
     viewCount: 1,
-    status : 1
+    status : 1,
+    thumbnailUrl : 1
   };
 
   const sort = searchObject.sort || { viewCount: -1 };


### PR DESCRIPTION
This pr will close #61 

There were multiple reasons for broken thumbnail.

-  After generating a thumbnail, url used to store in `thumbnailUrl`.  This filed was not present inside video schema validator. As we are using `additionalProperties = false`, mongo through `Document Validation Error` when we tried to store `thumbnailUrl`. Along with  `thumbnailUrl` there were other fields (`thumbnailPath`, `processedPath`, `hlsPath`, `history`) which were not present in `schema validator`.

- `search` api was not sending `thumbnailUrl` with response.