### PR TITLE
Logging with Elastic stack

### DIFF
--- a/server/.ef670e866adee2a3b2bd408d90586049413043f9-audit.json
+++ b/server/.ef670e866adee2a3b2bd408d90586049413043f9-audit.json
@@ -1,0 +1,20 @@
+{
+    "keep": {
+        "days": true,
+        "amount": 14
+    },
+    "auditLog": ".ef670e866adee2a3b2bd408d90586049413043f9-audit.json",
+    "files": [
+        {
+            "date": 1695732103032,
+            "name": "application-2023-09-26-18.log",
+            "hash": "79ee3cf2b1fa330f399d3b775bd859db3a9f62a9af4c9c33bbe786dc0d222457"
+        },
+        {
+            "date": 1695746509756,
+            "name": "application-2023-09-26-22.log",
+            "hash": "90f46d8772b164be1848255e9d234603a4a51516c958579d1c5b901b9e59363e"
+        }
+    ],
+    "hashType": "sha256"
+}

--- a/server/.env.template
+++ b/server/.env.template
@@ -1,5 +1,8 @@
+NODE_ENV=development
 MONGODB_URL=mongodb://localhost:27017
 SERVER_URL=http://localhost:4000
 LOGGLY_TOKEN=1234-5678-9012
 ENABLE_WINSTON_MONGODB=true
 ENABLE_WINSTON_LOGGLY=true
+APM_SERVER_URL=http://localhost:8200
+IS_APM_ACTIVE= true (whether to send api performence to elasticsearch using elastic APM)

--- a/server/EKA-docker/.env.template
+++ b/server/EKA-docker/.env.template
@@ -1,0 +1,10 @@
+ELASTICSEARCH_USERNAME=elastic (default elastic superuser)
+ELASTICSEARCH_PASSWORD=elastic superuser password
+FILEBEAT_ROLE_NAME=role name for filebeat user
+FILEBEAT_USERNAME=filebeat username
+FILEBEAT_PASSWORD=filebeat user password
+KIBANA_USERNAME=kibana_system (default kibana user)
+KIBANA_PASSWORD=kibana user password
+APM_ROLE_NAME=role name for apm user
+APM_USERNAME=apm username
+APM_PASSWORD=apm user password

--- a/server/EKA-docker/README.md
+++ b/server/EKA-docker/README.md
@@ -1,0 +1,37 @@
+## Services
+
+* [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html) - For storing data 
+* [APM](https://www.elastic.co/guide/en/apm/guide/current/apm-overview.html) - For tracking application performence
+* [Filebeat](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-overview.html) - For Shipping log to elasticsearch 
+* [Kibana](https://www.elastic.co/guide/en/kibana/8.10/introduction.html) - For visualization
+
+## Installation
+
+* create `.env` file and populate all the required environment variable (see `.ent.template` for reference)
+
+* build the container 
+
+  ```bash
+  docker-compose up --build
+  ```
+
+if everything went well, you will find `kibana` running at `http://localhost:5601/`. 
+To log into `kibana dashboard` use values of `ELASTICSEARCH_USERNAME` & `ELASTICSEARCH_PASSWORD` of your env variable.
+
+
+#### To see application log -
+
+From sidebar navigate to Observability > Logs
+
+#### To see APM log -
+
+From sidebar navigate to Observability > APM
+
+
+
+
+
+
+
+
+

--- a/server/EKA-docker/apm_role.json
+++ b/server/EKA-docker/apm_role.json
@@ -1,0 +1,23 @@
+{
+    "indices": [
+      {
+        "names": [
+          "apm-*",
+          ".apm-*source-map",
+          "apm-*sourcemap*",
+          "traces-apm*",
+          "logs-apm*",
+          "metrics-apm*",
+          "monitoring-beats-*"
+        ],
+        "privileges": [
+          "manage",
+          "create_doc",
+          "create_index",
+          "read",
+          "all",
+          "auto_configure"
+        ]
+      }
+    ]
+  }

--- a/server/EKA-docker/docker-compose.yml
+++ b/server/EKA-docker/docker-compose.yml
@@ -82,12 +82,10 @@ services:
       timeout: 10s
       retries: 120
 
-  # Kibana to display monitoring data
+  # APM for mesuring performance
   apm-server:
     depends_on:
       elasticsearch:
-        condition: service_healthy
-      kibana:
         condition: service_healthy
     image: docker.elastic.co/apm/apm-server:8.7.1
     container_name: apm-server
@@ -108,18 +106,32 @@ services:
       interval: 10s
       retries: 120
       test: curl -I --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null https://localhost:8200/
+  
+  # Filebeat for sending logs to elasticsearch
+  filebeat:
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    image: docker.elastic.co/beats/filebeat:8.7.1
+    container_name: filebeat
+    # command: >
+    #   bash -c '
+    #     chmod go-w /usr/share/filebeat/filebeat.yml;
+    #   '
+    volumes:
+      - ../logs:/var/log/server
+      - ./filebeat.yml:/usr/share/filebeat/filebeat.yml
+    restart: unless-stopped
+    environment:
+      - ELASTICSEARCH_HOST=${ELASTICSEARCH_HOST:-elasticsearch}
+      - KIBANA_HOST=${KIBANA_HOST:-kibana}
+      - ELASTICSEARCH_USERNAME=${ELASTICSEARCH_USERNAME:-elastic}
+      - ELASTICSEARCH_PASSWORD=${ELASTICSEARCH_PASSWORD:-change_me}
+    labels:
+      co.elastic.logs/json.overwrite_keys: true 
+      co.elastic.logs/json.add_error_key: true 
+      co.elastic.logs/json.expand_keys: true 
 
 volumes:
   elasticsearch-data:
     driver: local
-
-# networks:
-#   es-net:
-#     driver: bridge
-
-
-        #  -E apm-server.kibana.username=elastic
-        #  -E apm-server.kibana.password=change_me
-        #  -E apm-server.kibana.enabled=true
-        #  -E apm-server.kibana.host=kibana:5601
-        #  -E apm-server.kibana.protocol=http

--- a/server/EKA-docker/docker-compose.yml
+++ b/server/EKA-docker/docker-compose.yml
@@ -1,0 +1,125 @@
+version: '3.8'
+
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.1
+    container_name: elasticsearch
+    environment:
+      - node.name=elasticsearch
+      - path.logs=/var/log/
+      - cluster.name=elasticsearch
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
+      - ELASTICSEARCH_USERNAME=kibana_system
+      - ELASTIC_PASSWORD=change_me
+      - bootstrap.memory_lock=true
+      - xpack.security.enabled=true
+      - xpack.security.authc.api_key.enabled=true
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data  
+    ports:
+      - 9200:9200
+    healthcheck:
+        test: 
+          [
+            "CMD-SHELL", 
+            "curl -s -I http://localhost:9200/_cluster/health || exit 1"
+          ]
+        interval: 10s
+        timeout: 10s
+        retries: 120
+
+  elasticsearch-setup:
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.1
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/config/certs
+    user: "0"
+    command: >
+      bash -c '
+        echo "Waiting for Elasticsearch availability";
+        until curl -s http://elasticsearch:9200 | grep -q "missing authentication credentials"; do sleep 30; done;
+        echo "Setting kibana_system password";
+        until curl -s -X POST  -u "elastic:change_me" -H "Content-Type: application/json" http://elasticsearch:9200/_security/user/kibana_system/_password -d "{\"password\":\"change_me\"}" | grep -q "^{}"; do sleep 10; done;
+        echo "All done!";
+      '
+      # curl -s -X GET  -u "elastic:change_me" -H "Content-Type: application/json" http://elasticsearch:9200/_security/user?pretty
+    healthcheck:
+      test: ["CMD-SHELL", "[ -f config/certs/elasticsearch/elasticsearch.crt ]"]
+      interval: 1s
+      timeout: 5s
+      retries: 120
+
+  # Kibana to display monitoring data
+  kibana:
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    image: docker.elastic.co/kibana/kibana:8.7.1
+    container_name: kibana
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - ELASTICSEARCH_USERNAME=kibana_system
+      - ELASTICSEARCH_PASSWORD=change_me
+
+    volumes:
+      - ./kibana.yml:/usr/share/kibana/config/kibana.yml
+    ports:
+      - 5601:5601
+    # networks:
+    #   - es-net
+
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302 Found'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 120
+
+  # Kibana to display monitoring data
+  apm-server:
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+      kibana:
+        condition: service_healthy
+    image: docker.elastic.co/apm/apm-server:8.7.1
+    container_name: apm-server
+    ports:
+      - 8200:8200
+    command: >
+       apm-server -e
+         -E apm-server.rum.enabled=true
+         -E setup.kibana.host=kibana:5601
+         -E setup.template.settings.index.number_of_replicas=0
+         -E output.elasticsearch.hosts=["http://elasticsearch:9200"]
+         -E output.elasticsearch.username=elastic
+         -E output.elasticsearch.password=change_me
+
+    # networks:
+    #   - es-net
+    healthcheck:
+      interval: 10s
+      retries: 120
+      test: curl -I --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null https://localhost:8200/
+
+volumes:
+  elasticsearch-data:
+    driver: local
+
+# networks:
+#   es-net:
+#     driver: bridge
+
+
+        #  -E apm-server.kibana.username=elastic
+        #  -E apm-server.kibana.password=change_me
+        #  -E apm-server.kibana.enabled=true
+        #  -E apm-server.kibana.host=kibana:5601
+        #  -E apm-server.kibana.protocol=http

--- a/server/EKA-docker/docker-compose.yml
+++ b/server/EKA-docker/docker-compose.yml
@@ -11,8 +11,8 @@ services:
       - cluster.name=elasticsearch
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
-      - ELASTICSEARCH_USERNAME=kibana_system
-      - ELASTIC_PASSWORD=change_me
+      - ELASTICSEARCH_USERNAME=${ELASTICSEARCH_USERNAME:-elastic}
+      - ELASTIC_PASSWORD=${ELASTICSEARCH_PASSWORD:-change_me}
       - bootstrap.memory_lock=true
       - xpack.security.enabled=true
       - xpack.security.authc.api_key.enabled=true
@@ -30,6 +30,7 @@ services:
         timeout: 10s
         retries: 120
 
+
   elasticsearch-setup:
     depends_on:
       elasticsearch:
@@ -37,21 +38,37 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.7.1
     volumes:
       - elasticsearch-data:/usr/share/elasticsearch/config/certs
+      - ./filebeat_role.json:/usr/share/elasticsearch/role/filebeat_role.json
+      - ./apm_role.json:/usr/share/elasticsearch/role/apm_role.json
     user: "0"
     command: >
       bash -c '
         echo "Waiting for Elasticsearch availability";
         until curl -s http://elasticsearch:9200 | grep -q "missing authentication credentials"; do sleep 30; done;
+
         echo "Setting kibana_system password";
-        until curl -s -X POST  -u "elastic:change_me" -H "Content-Type: application/json" http://elasticsearch:9200/_security/user/kibana_system/_password -d "{\"password\":\"change_me\"}" | grep -q "^{}"; do sleep 10; done;
+        until curl -s -X POST  -u "${ELASTICSEARCH_USERNAME:-elastic}:${ELASTICSEARCH_PASSWORD:-change_me}" -H "Content-Type: application/json" http://elasticsearch:9200/_security/user/${KIBANA_USERNAME:-kibana_system}/_password -d "{\"password\":\"${KIBANA_PASSWORD:-change_me}\"}" | grep -q "^{}"; do sleep 10; done;
+
+        echo "Adding apm writer role";
+        until curl -s -X PUT  -u "${ELASTICSEARCH_USERNAME:-elastic}:${ELASTICSEARCH_PASSWORD:-change_me}" -H "Content-Type: application/json" http://elasticsearch:9200/_security/role/${APM_ROLE_NAME:-apm_setup}/ -d @/usr/share/elasticsearch/role/apm_role.json | grep -q "created"; do sleep 10; done;
+                
+        echo "Creating apm writer user";
+        until curl -s -X PUT  -u "${ELASTICSEARCH_USERNAME:-elastic}:${ELASTICSEARCH_PASSWORD:-change_me}" -H "Content-Type: application/json" http://elasticsearch:9200/_security/user/${APM_USERNAME:-apm_writer}/ -d "{\"password\":\"${APM_PASSWORD:-change_me}\", \"roles\": [\"${APM_ROLE_NAME:-apm_setup}\",\"apm_system\"]}" | grep -q "created"; do sleep 10; done;
+       
+        echo "Adding filebeat writer role";
+        until curl -s -X PUT  -u "${ELASTICSEARCH_USERNAME:-elastic}:${ELASTICSEARCH_PASSWORD:-change_me}" -H "Content-Type: application/json" http://elasticsearch:9200/_security/role/${FILEBEAT_ROLE_NAME:-filebeat_setup}/ -d @/usr/share/elasticsearch/role/filebeat_role.json | grep -q "created"; do sleep 10; done;
+                
+        echo "Creating filebeat writer user";
+        until curl -s -X PUT  -u "${ELASTICSEARCH_USERNAME:-elastic}:${ELASTICSEARCH_PASSWORD:-change_me}" -H "Content-Type: application/json" http://elasticsearch:9200/_security/user/${FILEBEAT_USERNAME:-filebeat_writer}/ -d "{\"password\":\"${FILEBEAT_PASSWORD:-change_me}\", \"roles\": [\"${FILEBEAT_ROLE_NAME:-filebeat_setup}\"]}" | grep -q "created"; do sleep 10; done;
+        
         echo "All done!";
       '
-      # curl -s -X GET  -u "elastic:change_me" -H "Content-Type: application/json" http://elasticsearch:9200/_security/user?pretty
     healthcheck:
       test: ["CMD-SHELL", "[ -f config/certs/elasticsearch/elasticsearch.crt ]"]
       interval: 1s
       timeout: 5s
       retries: 120
+
 
   # Kibana to display monitoring data
   kibana:
@@ -62,16 +79,12 @@ services:
     container_name: kibana
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
-      - ELASTICSEARCH_USERNAME=kibana_system
-      - ELASTICSEARCH_PASSWORD=change_me
-
+      - ELASTICSEARCH_USERNAME=${KIBANA_USERNAME:-kibana_system}
+      - ELASTICSEARCH_PASSWORD=${KIBANA_PASSWORD:-change_me}
     volumes:
       - ./kibana.yml:/usr/share/kibana/config/kibana.yml
     ports:
       - 5601:5601
-    # networks:
-    #   - es-net
-
     healthcheck:
       test:
         [
@@ -81,6 +94,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 120
+
 
   # APM for mesuring performance
   apm-server:
@@ -96,18 +110,16 @@ services:
          -E apm-server.rum.enabled=true
          -E setup.kibana.host=kibana:5601
          -E setup.template.settings.index.number_of_replicas=0
-         -E output.elasticsearch.hosts=["http://elasticsearch:9200"]
-         -E output.elasticsearch.username=elastic
-         -E output.elasticsearch.password=change_me
-
-    # networks:
-    #   - es-net
+         -E output.elasticsearch.hosts=http://elasticsearch:9200
+         -E output.elasticsearch.username=${APM_USERNAME:-apm_writer}
+         -E output.elasticsearch.password=${APM_PASSWORD:-change_me}
     healthcheck:
       interval: 10s
       retries: 120
       test: curl -I --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null https://localhost:8200/
   
-  # Filebeat for sending logs to elasticsearch
+
+  # # Filebeat for sending logs to elasticsearch
   filebeat:
     depends_on:
       elasticsearch:
@@ -123,10 +135,9 @@ services:
       - ./filebeat.yml:/usr/share/filebeat/filebeat.yml
     restart: unless-stopped
     environment:
-      - ELASTICSEARCH_HOST=${ELASTICSEARCH_HOST:-elasticsearch}
-      - KIBANA_HOST=${KIBANA_HOST:-kibana}
-      - ELASTICSEARCH_USERNAME=${ELASTICSEARCH_USERNAME:-elastic}
-      - ELASTICSEARCH_PASSWORD=${ELASTICSEARCH_PASSWORD:-change_me}
+      - ELASTICSEARCH_HOST=elasticsearch
+      - ELASTICSEARCH_USERNAME=${FILEBEAT_USERNAME:-filebeat_writer}
+      - ELASTICSEARCH_PASSWORD=${FILEBEAT_PASSWORD:-change_me}
 
 volumes:
   elasticsearch-data:

--- a/server/EKA-docker/docker-compose.yml
+++ b/server/EKA-docker/docker-compose.yml
@@ -127,10 +127,6 @@ services:
       - KIBANA_HOST=${KIBANA_HOST:-kibana}
       - ELASTICSEARCH_USERNAME=${ELASTICSEARCH_USERNAME:-elastic}
       - ELASTICSEARCH_PASSWORD=${ELASTICSEARCH_PASSWORD:-change_me}
-    labels:
-      co.elastic.logs/json.overwrite_keys: true 
-      co.elastic.logs/json.add_error_key: true 
-      co.elastic.logs/json.expand_keys: true 
 
 volumes:
   elasticsearch-data:

--- a/server/EKA-docker/filebeat.yml
+++ b/server/EKA-docker/filebeat.yml
@@ -1,0 +1,15 @@
+filebeat.inputs:
+- type: log
+  enabled: true
+  paths:
+  - "/var/log/server/*.log"
+processors: 
+  - add_host_metadata: ~
+  # - add_cloud_metadata: ~
+  # - add_docker_metadata: ~
+  # - add_kubernetes_metadata: ~
+
+output.elasticsearch:
+  hosts: ["${ELASTICSEARCH_HOST}:9200"]
+  username: ${ELASTICSEARCH_USERNAME}
+  password: ${ELASTICSEARCH_PASSWORD}

--- a/server/EKA-docker/filebeat.yml
+++ b/server/EKA-docker/filebeat.yml
@@ -1,8 +1,14 @@
 filebeat.inputs:
-- type: log
+- type: filestream
   enabled: true
   paths:
   - "/var/log/server/*.log"
+  parsers:
+    - ndjson:
+      overwrite_keys: true 
+      add_error_key: true 
+      expand_keys: true 
+
 processors: 
   - add_host_metadata: ~
   # - add_cloud_metadata: ~
@@ -13,3 +19,6 @@ output.elasticsearch:
   hosts: ["${ELASTICSEARCH_HOST}:9200"]
   username: ${ELASTICSEARCH_USERNAME}
   password: ${ELASTICSEARCH_PASSWORD}
+  
+# output.console:
+#     pretty: true

--- a/server/EKA-docker/filebeat_role.json
+++ b/server/EKA-docker/filebeat_role.json
@@ -1,0 +1,22 @@
+{
+    "cluster": [
+      "manage",
+      "monitor",
+      "read_pipeline",
+      "read_ilm"
+    ],
+    "indices": [
+      {
+        "names": [
+          "filebeat-*",
+          ".ds-filebeat-*"
+        ],
+        "privileges": [
+          "manage",
+          "create_doc",
+          "view_index_metadata",
+          "create_index"
+        ]
+      }
+    ]
+  }

--- a/server/EKA-docker/kibana.yml
+++ b/server/EKA-docker/kibana.yml
@@ -1,0 +1,10 @@
+server.host: 0.0.0.0
+status.allowAnonymous: true
+monitoring.ui.container.elasticsearch.enabled: true
+telemetry.enabled: false
+xpack.security.encryptionKey: fhjskloppd678ehkdfdlliverpoolfcr
+xpack.encryptedSavedObjects.encryptionKey: fhjskloppd678ehkdfdlliverpoolfcr
+
+# xpack.fleet.packages:
+#   - name: apm
+#     version: latest

--- a/server/EKA-docker/kibana.yml
+++ b/server/EKA-docker/kibana.yml
@@ -5,6 +5,6 @@ telemetry.enabled: false
 xpack.security.encryptionKey: fhjskloppd678ehkdfdlliverpoolfcr
 xpack.encryptedSavedObjects.encryptionKey: fhjskloppd678ehkdfdlliverpoolfcr
 
-# xpack.fleet.packages:
-#   - name: apm
-#     version: latest
+xpack.fleet.packages:
+  - name: apm
+    version: latest

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@elastic/ecs-winston-format": "^1.3.1",
     "bcrypt": "^5.1.0",
     "bullmq": "^3.5.11",
     "compression": "^1.7.4",

--- a/server/package.json
+++ b/server/package.json
@@ -32,6 +32,7 @@
     "cors": "^2.8.5",
     "cron": "^2.2.0",
     "dotenv": "^16.3.1",
+    "elastic-apm-node": "^4.0.0",
     "express": "^4.18.2",
     "express-pino-logger": "^7.0.0",
     "express-rate-limit": "^6.7.0",

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -4,11 +4,12 @@ const cors = require('cors');
 require('dotenv').config();
 
 
-var apm = require('elastic-apm-node').start({
+require('elastic-apm-node').start({
   serviceName: 'mern-video-streaming',
   // secretToken: '',
-  serverUrl: 'http://localhost:8200',
-  environment: 'development'
+  serverUrl: process.env.APM_SERVER_URL,
+  environment: process.env.NODE_ENV,
+  active: process.env.NODE_ENV === "production" || process.env.IS_APM_ACTIVE
 })
 
 

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,8 +1,10 @@
 const express = require('express');
 const compression = require('compression');
 const cors = require('cors');
-require('dotenv').config();
+const morgan = require('morgan');
+const logger = require('./logger');
 
+require('dotenv').config();
 
 require('elastic-apm-node').start({
   serviceName: 'mern-video-streaming',
@@ -12,11 +14,26 @@ require('elastic-apm-node').start({
   active: process.env.NODE_ENV === "production" || process.env.IS_APM_ACTIVE
 })
 
-
 const app = express();
 app.use(express.json());
 app.use(compression());
 app.use(cors());
+
+if(!process.env.IS_APM_ACTIVE){
+  const morganMiddleware = morgan(
+    ':method :url :status :res[content-length] - :response-time ms',
+    {
+      stream: {
+        // Configure Morgan to use our custom logger with the http severity
+        write: (message) => logger.http(message.trim()),
+      },
+    }
+  );
+  
+  app.use(morganMiddleware);
+}
+
+
 app.use('/thumbnails', express.static('./uploads/thumbnails'));
 
 module.exports = app;

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,27 +1,21 @@
-require('dotenv').config();
 const express = require('express');
 const compression = require('compression');
 const cors = require('cors');
-const morgan = require('morgan');
-const app = express();
+require('dotenv').config();
 
+
+var apm = require('elastic-apm-node').start({
+  serviceName: 'mern-video-streaming',
+  // secretToken: '',
+  serverUrl: 'http://localhost:8200',
+  environment: 'development'
+})
+
+
+const app = express();
 app.use(express.json());
 app.use(compression());
 app.use(cors());
-
-const logger = require('./logger');
-
-const morganMiddleware = morgan(
-  ':method :url :status :res[content-length] - :response-time ms',
-  {
-    stream: {
-      // Configure Morgan to use our custom logger with the http severity
-      write: (message) => logger.http(message.trim()),
-    },
-  }
-);
-app.use(morganMiddleware);
-
 app.use('/thumbnails', express.static('./uploads/thumbnails'));
 
 module.exports = app;

--- a/server/src/logger.js
+++ b/server/src/logger.js
@@ -1,30 +1,33 @@
 const os = require('os');
 const { createLogger, format, transports } = require('winston');
 const { Loggly } = require('winston-loggly-bulk');
+const ecsFormat = require('@elastic/ecs-winston-format')
 require('winston-daily-rotate-file');
 
+const LOG_DIR = 'logs'
 class LogManager {
   static instance;
   constructor() {
     this.logger = createLogger({
       level: 'info',
-      format: format.combine(
-        format.timestamp({
-          format: 'YYYY-MM-DD HH:mm:ss',
-        }),
-        format.errors({ stack: true }),
-        format.splat(),
-        format.json()
-      ),
-      exceptionHandlers: [new transports.File({ filename: 'exception.log' })],
-      rejectionHandlers: [new transports.File({ filename: 'rejections.log' })],
+      // format:format.combine(
+      //   format.timestamp({
+      //     format: 'YYYY-MM-DD HH:mm:ss',
+      //   }),
+      //   format.errors({ stack: true }),
+      //   format.splat(),
+      //   format.json()
+      // ),
+      format: ecsFormat(),
+      exceptionHandlers: [new transports.File({ filename: `${LOG_DIR}/exception.log` })],
+      rejectionHandlers: [new transports.File({ filename: `${LOG_DIR}/rejections.log` })],
       defaultMeta: { service: process.env.npm_lifecycle_event },
       transports: [
-        new transports.File({ filename: 'error.log', level: 'error' }),
-        new transports.File({ filename: 'combined.log' }),
+        new transports.File({ filename: `${LOG_DIR}/error.log`, level: 'error' }),
+        new transports.File({ filename: `${LOG_DIR}/combined.log` }),
         new transports.DailyRotateFile({
           level: 'info',
-          filename: 'application-%DATE%.log',
+          filename: `${LOG_DIR}/application-%DATE%.log`,
           datePattern: 'YYYY-MM-DD-HH',
           zippedArchive: true,
           maxSize: '20m',

--- a/server/src/modules/models/video/controller.js
+++ b/server/src/modules/models/video/controller.js
@@ -17,11 +17,11 @@ const {
 const BASE_URL = `/api/videos`;
 
 const setupRoutes = (app) => {
-  console.log(`Setting up routes for ${BASE_URL}`);
+  // console.log(`Setting up routes for ${BASE_URL}`);
 
   // return empty response with success message for the base route
   app.get(`${BASE_URL}/`, async (req, res) => {
-    console.log(`GET`, req.params);
+    // console.log(`GET`, req.params);
     const data = await search({});
     res.send({
       status: 'success',
@@ -32,7 +32,7 @@ const setupRoutes = (app) => {
   });
 
   app.get(`${BASE_URL}/detail/:id`, async (req, res) => {
-    console.log(`GET`, req.params);
+    // console.log(`GET`, req.params);
     const video = await updateViewCount(req.params.id);
     if (video instanceof Error) {
       return res.status(400).json(JSON.parse(video.message));
@@ -42,13 +42,13 @@ const setupRoutes = (app) => {
 
   // TODO: Proper searching with paging and ordering
   app.post(`${BASE_URL}/search`, async (req, res) => {
-    console.log('POST search', req.body);
+    // console.log('POST search', req.body);
     const result = await search(req.body);
     res.send(result);
   });
 
   app.post(`${BASE_URL}/count`, async (req, res) => {
-    console.log('POST count', req.body);
+    // console.log('POST count', req.body);
     const result = await count(req.body);
     res.send({count: result});
   });
@@ -84,7 +84,7 @@ const setupRoutes = (app) => {
   });
 
   app.delete(`${BASE_URL}/delete/:id`, async (req, res) => {
-    console.log('DELETE', req.params.id);
+    // console.log('DELETE', req.params.id);
     if (req.params.id) {
       const result = await deleteById(req.params.id);
       if (result instanceof Error) {
@@ -110,10 +110,10 @@ const setupRoutes = (app) => {
 
   const fileFilter = (req, file, cb) => {
     if (file.mimetype === 'video/mp4' || file.mimetype === 'video/webm') {
-      console.log('file type supported', file);
+      // console.log('file type supported', file);
       cb(null, true);
     } else {
-      console.log('file type not supported', file);
+      // console.log('file type not supported', file);
       cb(new multer.MulterError('File type not supported'), false);
     }
   };
@@ -132,7 +132,7 @@ const setupRoutes = (app) => {
         res.status(400).json({ status: 'error', error: err });
         return;
       } else {
-        console.log('upload success', req.file);
+        // console.log('upload success', req.file);
         // res.status(200).json({ status: "success", message: "upload success" });
         next();
       }
@@ -155,10 +155,10 @@ const setupRoutes = (app) => {
         viewCount: 0,
         duration: 0,
       };
-      console.log('dbPayload', dbPayload);
+      // console.log('dbPayload', dbPayload);
       // TODO: save the file info and get the id from the database
       const result = await insert(dbPayload);
-      console.log('result', result);
+      // console.log('result', result);
       await addQueueItem(QUEUE_EVENTS.VIDEO_UPLOADED, {
         id: result.insertedId.toString(),
         ...req.body,


### PR DESCRIPTION
This pr will close #86 

Crete a `docker-compose` file for running Elastic Stack. The container will run 4 services -

* [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html) - For storing data 
* [APM](https://www.elastic.co/guide/en/apm/guide/current/apm-overview.html) - For tracking application performence
* [Filebeat](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-overview.html) - For Shipping log to elasticsearch 
* [Kibana](https://www.elastic.co/guide/en/kibana/8.10/introduction.html) - For visualization

To write application log on log file, we use  `@elastic/ecs-winston-format` package for formatting log into [`ECS`](https://www.elastic.co/guide/en/ecs/current/ecs-reference.html) format, this format help `filebeat` to parse log properly and also this package add a extra `trace id` along with other data with each log



 

